### PR TITLE
PAY-7303: Remove legacy servicebus configuration

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -23,7 +23,7 @@ def vaultOverrides = [
 ]
 def secrets = [
   'ccpay-${env}': [
-    secret('ccpay-service-request-cpo-update-topic-shared-access-key', 'AMQP_SHARED_ACCESS_KEY_VALUE'),
+    secret('ccpay-service-request-cpo-update-topic-premium-shared-access-key', 'AMQP_SHARED_ACCESS_KEY_VALUE'),
     secret('service-request-cpo-update-service-s2s-secret', 'OIDC_S2S_SECRET')
   ]
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -243,8 +243,12 @@ dependencies {
     }
 
     implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '3.0.3'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
     implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.2.0'
+
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.6'
+    implementation group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.1.0'
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -242,9 +242,9 @@ dependencies {
       exclude module: 'adal4j'
     }
 
-    implementation group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.4'
+    implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '3.0.3'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
-    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
+    implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.2.0'
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,6 @@ apply from: "${rootDir}/cve-resolution-strategy.gradle"
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
   maven { url 'https://jitpack.io' }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -46,42 +46,6 @@ resource "azurerm_key_vault_secret" "ccpay_service_request_cpo_update_topic_prem
   key_vault_id = data.azurerm_key_vault.ccpay_key_vault.id
 }
 
-######################################
-# START Old Service Bus Namespace
-# TBD: Remove this block after migration
-######################################
-
-data "azurerm_servicebus_namespace" "ccpay_servicebus_namespace" {
-  name                = join("-", [var.product, "servicebus", var.env])
-  resource_group_name = join("-", [var.product, var.env])
-}
-
-module "service_request_cpo_update_topic" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-topic"
-  name                  = "ccpay-service-request-cpo-update-topic"
-  namespace_name        = data.azurerm_servicebus_namespace.ccpay_servicebus_namespace.name
-  resource_group_name   = data.azurerm_resource_group.rg.name
-}
-
-module "service_request_cpo_update_subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription"
-  name                  = local.subscription_name
-  namespace_name        = data.azurerm_servicebus_namespace.ccpay_servicebus_namespace.name
-  resource_group_name   = data.azurerm_resource_group.rg.name
-  topic_name            = module.service_request_cpo_update_topic.name
-  depends_on            = [module.service_request_cpo_update_topic]
-}
-
-resource "azurerm_key_vault_secret" "ccpay_service_request_cpo_update_topic_shared_access_key" {
-  name         = "ccpay-service-request-cpo-update-topic-shared-access-key"
-  value        = module.service_request_cpo_update_topic.primary_send_and_listen_shared_access_key
-  key_vault_id = data.azurerm_key_vault.ccpay_key_vault.id
-}
-
-######################################
-# END Old Service Bus Namespace
-######################################
-
 data "azurerm_key_vault" "s2s_key_vault" {
   name                = local.s2s_key_vault_name
   resource_group_name = local.s2s_vault_resource_group


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-7303


### Change description ###
Old servicebus namespace still being referenced, even though it's been removed! Removing old config.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
